### PR TITLE
Add support for `link` tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = document
 function document(options) {
   var settings = options || {}
   var meta = settings.meta || []
+  var link = settings.link || []
   var css = settings.css || []
   var js = settings.js || []
 
@@ -21,6 +22,10 @@ function document(options) {
       name: 'viewport',
       content: 'width=device-width, initial-scale=1'
     })
+  }
+
+  if (!('length' in link)) {
+    link = [link]
   }
 
   if (typeof css === 'string') {
@@ -53,6 +58,13 @@ function document(options) {
 
     while (++index < length) {
       head.push(line(), h('meta', meta[index]))
+    }
+
+    length = link.length
+    index = -1
+
+    while (++index < length) {
+      head.push(line(), h('link', link[index]))
     }
 
     length = css.length

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,12 @@ Wrap a document around a fragment.
 Each object is passed as [`properties`][props] to [`hastscript`][h] with a `meta`
 element.
 
+###### `options.link`
+
+`Object` or `Array.<Object>`, default: `[]` — Link tags to include in `head`.
+Each object is passed as [`properties`][props] to [`hastscript`][h] with a `link`
+element.
+
 ###### `options.js`
 
 `string` or `Array.<string>`, default: `[]` — Scripts to include at end of

--- a/test.js
+++ b/test.js
@@ -210,6 +210,61 @@ test('document()', function(t) {
   t.equal(
     rehype()
       .data('settings', {fragment: true})
+      .use(document, {link: {rel: 'canonical', href: 'http://example.com'}})
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '<link rel="canonical" href="http://example.com">',
+      '</head>',
+      '<body>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should support `link` as `object`'
+  )
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(document, {
+        link: [
+          {rel: 'canonical', href: 'http://example.com'},
+          {
+            rel: 'alternate',
+            href: '/feed.xml',
+            type: 'application/atom+xml',
+            title: 'Feed'
+          }
+        ]
+      })
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '<link rel="canonical" href="http://example.com">',
+      '<link rel="alternate" href="/feed.xml" type="application/atom+xml" title="Feed">',
+      '</head>',
+      '<body>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should support `link` as `array`'
+  )
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
       .use(document, {css: 'delta.css'})
       .processSync('')
       .toString(),


### PR DESCRIPTION
Besides stylesheets, link tags can also be added to the `head` for things like [url prefetching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ), [syndication feeds](https://developer.mozilla.org/en-US/docs/Web/RSS/Getting_Started/Syndicating), and [canonical urls](https://support.google.com/webmasters/answer/139066). This PR adds support for all this, the same way that `meta` tags already work right now.