### PR TITLE
Add support for inline style elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function document(options) {
   var settings = options || {}
   var meta = cast(settings.meta)
   var link = cast(settings.link)
+  var styles = cast(settings.style)
   var css = cast(settings.css)
   var js = cast(settings.js)
 
@@ -49,6 +50,14 @@ function document(options) {
 
     while (++index < length) {
       head.push(line(), h('link', link[index]))
+    }
+
+    // Inject style tags before linked css
+    length = styles.length
+    index = -1
+
+    while (++index < length) {
+      head.push(line(), h('style', styles[index]))
     }
 
     length = css.length

--- a/readme.md
+++ b/readme.md
@@ -95,11 +95,13 @@ Whether to insert a `meta[viewport]` (`boolean`, default: `true`).
 
 ###### options.style
 
-CSS to include in `head` in `<style>` elements (`string` or `Array.<string>`, default: `[]`).
+CSS to include in `head` in `<style>` elements (`string` or `Array.<string>`,
+default: `[]`).
 
 ###### `options.css`
 
-Links to stylesheets to include in `head` (`string` or `Array.<string>`, default: `[]`).
+Links to stylesheets to include in `head` (`string` or `Array.<string>`,
+default: `[]`).
 
 ###### `options.meta`
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,10 @@ Whether to insert a `meta[viewport]` (`boolean`, default: `true`).
 
 [Doctype][] to use (`string`, default: `'5'`).
 
+###### options.style
+
+Style tags to include in `head` (`string` or `Array.<string>`, default: `[]`).
+
 ###### `options.css`
 
 Stylesheets to include in `head` (`string` or `Array.<string>`, default: `[]`).

--- a/readme.md
+++ b/readme.md
@@ -95,11 +95,11 @@ Whether to insert a `meta[viewport]` (`boolean`, default: `true`).
 
 ###### options.style
 
-Style tags to include in `head` (`string` or `Array.<string>`, default: `[]`).
+CSS to include in `head` in `<style>` elements (`string` or `Array.<string>`, default: `[]`).
 
 ###### `options.css`
 
-Stylesheets to include in `head` (`string` or `Array.<string>`, default: `[]`).
+Links to stylesheets to include in `head` (`string` or `Array.<string>`, default: `[]`).
 
 ###### `options.meta`
 

--- a/test.js
+++ b/test.js
@@ -265,6 +265,51 @@ test('document()', function(t) {
   t.equal(
     rehype()
       .data('settings', {fragment: true})
+      .use(document, {style: 'body {color: blue}'})
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '<style>body {color: blue}</style>',
+      '</head>',
+      '<body>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should support `style` as `string`'
+  )
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(document, {style: ['body {color: blue}', 'a {color: red}']})
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '<style>body {color: blue}</style>',
+      '<style>a {color: red}</style>',
+      '</head>',
+      '<body>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should support `style` as `array`'
+  )
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
       .use(document, {css: 'delta.css'})
       .processSync('')
       .toString(),
@@ -310,6 +355,29 @@ test('document()', function(t) {
   t.equal(
     rehype()
       .data('settings', {fragment: true})
+      .use(document, {css: 'delta.css', style: 'a {color: red}'})
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '<style>a {color: red}</style>',
+      '<link rel="stylesheet" href="delta.css">',
+      '</head>',
+      '<body>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should inject `style` tags before `css`'
+  )
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
       .use(document, {js: 'golf.js'})
       .processSync('')
       .toString(),
@@ -326,7 +394,7 @@ test('document()', function(t) {
       '</html>',
       ''
     ].join('\n'),
-    'should support `css` as `string`'
+    'should support `js` as `string`'
   )
 
   t.equal(
@@ -349,7 +417,7 @@ test('document()', function(t) {
       '</html>',
       ''
     ].join('\n'),
-    'should support `css` as `Array.<string>`'
+    'should support `js` as `Array.<string>`'
   )
 
   t.end()


### PR DESCRIPTION
Sometimes it can be useful to include some CSS directly in `style` tags in the document. For example, essential styles needed for the first render are often included this way. This PR adds a `style` property to support this use case.