### PR TITLE
Add support for inline script elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function document(options) {
   var link = cast(settings.link)
   var styles = cast(settings.style)
   var css = cast(settings.css)
+  var scripts = cast(settings.script)
   var js = cast(settings.js)
 
   if (settings.responsive !== false) {
@@ -52,7 +53,7 @@ function document(options) {
       head.push(line(), h('link', link[index]))
     }
 
-    // Inject style tags before linked css
+    // Inject style tags before linked CSS
     length = styles.length
     index = -1
 
@@ -68,6 +69,14 @@ function document(options) {
     }
 
     head.push(line())
+
+    // Inject script tags before linked JS
+    length = scripts.length
+    index = -1
+
+    while (++index < length) {
+      body.push(line(), h('script', scripts[index]))
+    }
 
     length = js.length
     index = -1

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Whether to insert a `meta[viewport]` (`boolean`, default: `true`).
 
 [Doctype][] to use (`string`, default: `'5'`).
 
-###### options.style
+###### `options.style`
 
 CSS to include in `head` in `<style>` elements (`string` or `Array.<string>`,
 default: `[]`).
@@ -115,10 +115,15 @@ Link tags to include in `head` (`Object` or `Array.<Object>`, default: `[]`).
 Each object is passed as [`properties`][props] to [`hastscript`][h] with a
 `link` element.
 
+###### `options.script`
+
+Inline scripts to include at end of `body` (`string` or `Array.<string>`,
+default: `[]`).
+
 ###### `options.js`
 
-Scripts to include at end of `body` (`string` or `Array.<string>`, default:
-`[]`).
+External scripts to include at end of `body` (`string` or `Array.<string>`,
+default: `[]`).
 
 ## Security
 

--- a/test.js
+++ b/test.js
@@ -420,5 +420,75 @@ test('document()', function(t) {
     'should support `js` as `Array.<string>`'
   )
 
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(document, {script: 'console.log("Hello");'})
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '</head>',
+      '<body>',
+      '<script>console.log("Hello");</script>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should support `script` as `string`'
+  )
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(document, {
+        script: ['console.log("Hello");', 'console.log("World");']
+      })
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '</head>',
+      '<body>',
+      '<script>console.log("Hello");</script>',
+      '<script>console.log("World");</script>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should support `script` as `Array.<string>`'
+  )
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(document, {js: 'world.js', script: 'console.log("Hello");'})
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '</head>',
+      '<body>',
+      '<script>console.log("Hello");</script>',
+      '<script src="world.js"></script>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should inject `script` tags before `js`'
+  )
+
   t.end()
 })


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/rehypejs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/rehypejs/.github/blob/master/support.md
https://github.com/rehypejs/.github/blob/master/contributing.md
-->

Hi @wooorm! This PR adds a `script` option for injecting inline JS. I've implemented it the same way https://github.com/rehypejs/rehype-document/pull/7 did it for CSS.

Would you be open to adding this option to the library? :)

The parameter names are getting somewhat confusing now (`css`, `style`, `js`, `script`), it might make sense to rename these in the next major release.