### PR TITLE
Move @types/hast to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   ],
   "types": "types/index.d.ts",
   "dependencies": {
+    "@types/hast": "^2.0.0",
     "doctype": "^2.0.0",
     "hastscript": "^5.0.0",
     "unist-builder": "^2.0.0"
   },
   "devDependencies": {
-    "@types/hast": "^2.0.0",
     "browserify": "^16.0.0",
     "dtslint": "^3.0.0",
     "nyc": "^15.0.0",

--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,6 @@
 npm install rehype-document
 ```
 
-This package comes with types.
-If you’re using TypeScript, make sure to also install
-[`@types/hast`][ts-hast].
-
 ## Use
 
 Say `example.md` looks as follows:
@@ -212,5 +208,3 @@ abide by its terms.
 [xss]: https://en.wikipedia.org/wiki/Cross-site_scripting
 
 [sanitize]: https://github.com/rehypejs/rehype-sanitize
-
-[ts-hast]: https://www.npmjs.com/package/@types/hast


### PR DESCRIPTION
This allows TypeScript consumers to use this package without the need to add
additional dependencies.