### PR TITLE
Add `options.dir` to set direction

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
  * @property {string|undefined} [language='en']
  *   Natural language of document.
  *   Should be a [BCP 47](https://tools.ietf.org/html/bcp47) language tag.
- * @property {'ltr'|'rtl'|'auto'|undefined} [dir='ltr']
+ * @property {'ltr'|'rtl'|'auto'|undefined} [dir]
  *   Direction of the document.
  * @property {boolean|undefined} [responsive=true]
  *   Whether to insert a `meta[viewport]`.

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@
  * @property {string|undefined} [language='en']
  *   Natural language of document.
  *   Should be a [BCP 47](https://tools.ietf.org/html/bcp47) language tag.
+ * @property {'ltr'|'rtl'|'auto'|undefined} [dir='ltr']
+ *   Direction of the document.
  * @property {boolean|undefined} [responsive=true]
  *   Whether to insert a `meta[viewport]`.
  * @property {string|Array<string>|undefined} [style=[]]
@@ -127,7 +129,7 @@ export default function rehypeDocument(options = {}) {
       children: [
         doctype,
         {type: 'text', value: '\n'},
-        h('html', {lang: options.language || 'en'}, [
+        h('html', {lang: options.language || 'en', dir: options.dir}, [
           {type: 'text', value: '\n'},
           h('head', head),
           {type: 'text', value: '\n'},

--- a/readme.md
+++ b/readme.md
@@ -156,7 +156,7 @@ should be a [BCP 47][bcp47] language tag.
 
 Direction of the document (`'ltr'|'rtl'|'auto'`, default: `'ltr'`).
 
-> 👉 **Note**: if you don't set this, it won't be injected in the document, even though its value is `'ltr'`.
+> 👉 **Note**: if you don’t set this, it won’t be injected in the document.
 
 ###### `options.responsive`
 

--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,12 @@ should be a [BCP 47][bcp47] language tag.
 
 > 👉 **Note**: you should set this if the content isn’t in English.
 
+##### `options.dir`
+
+Direction of the document (`'ltr'|'rtl'|'auto'`, default: `'ltr'`).
+
+> 👉 **Note**: if you don't set this, it won't be injected in the document, even though its value is `'ltr'`.
+
 ###### `options.responsive`
 
 Whether to insert a `meta[viewport]` (`boolean`, default: `true`).

--- a/readme.md
+++ b/readme.md
@@ -154,9 +154,7 @@ should be a [BCP 47][bcp47] language tag.
 
 ##### `options.dir`
 
-Direction of the document (`'ltr'|'rtl'|'auto'`, default: `'ltr'`).
-
-> 👉 **Note**: if you don’t set this, it won’t be injected in the document.
+Direction of text in the document (`'ltr'`, `'rtl'`, `'auto'`, optional).
 
 ###### `options.responsive`
 

--- a/test.js
+++ b/test.js
@@ -93,6 +93,27 @@ test('rehypeDocument()', (t) => {
   t.equal(
     rehype()
       .data('settings', {fragment: true})
+      .use(rehypeDocument, {dir: 'rtl'})
+      .processSync('')
+      .toString(),
+    [
+      '<!doctype html>',
+      '<html lang="en" dir="rtl">',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '</head>',
+      '<body>',
+      '</body>',
+      '</html>',
+      ''
+    ].join('\n'),
+    'should support `dir`'
+  )
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
       .use(rehypeDocument, {responsive: false})
       .processSync('')
       .toString(),


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Added the `dir` option.

<!--do not edit: pr-->
