### PR TITLE
Fix option name in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ Configuration (TypeScript type).
   — direction of the document
 * `js` (`Array<string>` or `string`, optional)
   — URLs to scripts to use as `src` on `<script>`s
-* `lang` (`string`, default: `'en'`)
+* `language` (`string`, default: `'en'`)
   — language of document; should be a [BCP 47][bcp47] language tag
 * `link` (`Array<Properties>` or `Properties`, optional)
   — generate extra `<link>`s with these properties; passed as `properties`


### PR DESCRIPTION

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

The documentation says there's an option named `lang`, but it's actually named `language`.

<!--do not edit: pr-->
