### PR TITLE
Fix readonly array type error with Array.isArray

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,17 @@ import type {Properties} from 'hastscript'
 
 export {default} from './lib/index.js'
 
+// Currently needed to ensure `Array.isArray` does not cause type errors when
+// working with readonly arrays.
+//
+// More info [here](https://github.com/microsoft/TypeScript/issues/17002)
+declare global {
+  interface ArrayConstructor {
+    // type-coverage:ignore-next-line
+    isArray(arg: ReadonlyArray<any> | any): arg is ReadonlyArray<any>
+  }
+}
+
 /**
  * Fields supported by `rehype-document`.
  */


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Arehypejs&type=issues and https://github.com/orgs/rehypejs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Fixes type narrowing when using `Array.isArray` with read only arrays.

(Builds are currently failing/this fixes it. Documented in this issue -> https://github.com/rehypejs/rehype-document/issues/17)

<!--do not edit: pr-->